### PR TITLE
Keep Model Upright when Rotating

### DIFF
--- a/open3mod/OrbitCameraController.cs
+++ b/open3mod/OrbitCameraController.cs
@@ -96,7 +96,11 @@ namespace open3mod
 
             if (x != 0)
             {
-                _view *= Matrix4.CreateFromAxisAngle(_up, (float)(x * RotationSpeed * Math.PI / 180.0));
+                // Free Orbit
+                //_view *= Matrix4.CreateFromAxisAngle(_up, (float)(x * RotationSpeed * Math.PI / 180.0));
+                
+                // Constrained Orbit: Keep Model Upright when Rotating
+                _view *= Matrix4.CreateFromAxisAngle(Matrix4.Invert(_view).Column1.Xyz, (float)(x * RotationSpeed * Math.PI / 180.0));
             }
 
             if (y != 0)


### PR DESCRIPTION
Same with 'Rotate About Scene Floor' in Solidworks, or 'Constrained Orbit' in Fusion 360.
Keeps the camera orbit around Y axis of the world coordinate instead of the axis of camera itself.